### PR TITLE
Added Interface Capabilities for Friends Tab

### DIFF
--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -21,6 +21,9 @@ usersController.index = async function (req, res, next) {
         'sort-reputation': usersController.getUsersSortedByReputation,
         banned: usersController.getBannedUsers,
         flagged: usersController.getFlaggedUsers,
+
+        // Adding New Friends Tab (implemented as online for right now)
+        friends: usersController.getOnlineUsers,
     };
 
     if (req.query.query) {

--- a/themes/nodebb-theme-persona/templates/partials/users_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/users_list.tpl
@@ -15,6 +15,12 @@
         </div>
         <!-- ENDIF section_online -->
 
+        <!-- IF section_friends -->
+        <div class="friends">
+            <span class="timeago" title="{users.lastonlineISO}"></span>
+        </div>
+        <!-- ENDIF section_friends -->
+
         <!-- IF section_joindate -->
         <div class="joindate">
             <span class="timeago" title="{users.joindateISO}"></span>

--- a/themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/users_list_menu.tpl
@@ -7,5 +7,6 @@
     <!-- IF isAdminOrGlobalMod -->
     <li><a href="{config.relative_path}/users?section=flagged">[[users:most_flags]]</a></li>
     <li><a href="{config.relative_path}/users?section=banned">[[user:banned]]</a></li>
+    <li><a href="{config.relative_path}/users?section=friends">[[user:friends]]</a></li>
     <!-- ENDIF isAdminOrGlobalMod -->
 </ul>


### PR DESCRIPTION
This commit adds a friends tab to the NodeBB interface. It currently does not consist of any backend logic for displaying the friends of a user - only online users are displayed on the page. 

Resolves #21 