### PR TITLE
Fixed dropdown list not showing 'Unresolve Topic' field

### DIFF
--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -179,8 +179,8 @@ define('forum/category/tools', [
         socket.removeListener('event:topic_unlocked', setLockedState);
         socket.removeListener('event:topic_pinned', setPinnedState);
         socket.removeListener('event:topic_unpinned', setPinnedState);
-        socket.removeListener('event:topic_pinned', setResolvedState);
-        socket.removeListener('event:topic_unpinned', setResolvedState);
+        socket.removeListener('event:topic_resolved', setResolvedState);
+        socket.removeListener('event:topic_unresolved', setResolvedState);
         socket.removeListener('event:topic_moved', onTopicMoved);
     };
 
@@ -204,6 +204,7 @@ define('forum/category/tools', [
         const areAllDeleted = areAll(isTopicDeleted, tids);
         const isAnyPinned = isAny(isTopicPinned, tids);
         const isAnyLocked = isAny(isTopicLocked, tids);
+        const isAnyResolved = isAny(isTopicResolved, tids);
         const isAnyScheduled = isAny(isTopicScheduled, tids);
         const areAllScheduled = areAll(isTopicScheduled, tids);
 
@@ -216,6 +217,9 @@ define('forum/category/tools', [
 
         components.get('topic/pin').toggleClass('hidden', areAllScheduled || isAnyPinned);
         components.get('topic/unpin').toggleClass('hidden', areAllScheduled || !isAnyPinned);
+
+        components.get('topic/resolve').toggleClass('hidden', !isAnyResolved);
+        components.get('topic/unresolve').toggleClass('hidden', isAnyResolved);
 
         components.get('topic/merge').toggleClass('hidden', isAnyScheduled);
     }
@@ -250,6 +254,10 @@ define('forum/category/tools', [
         return getTopicEl(tid).hasClass('pinned');
     }
 
+    function isTopicResolved(tid) {
+        return getTopicEl(tid).hasClass('resolve');
+    }
+
     function isTopicScheduled(tid) {
         return getTopicEl(tid).hasClass('scheduled');
     }
@@ -273,7 +281,7 @@ define('forum/category/tools', [
 
     function setResolvedState(data) {
         const topic = getTopicEl(data.tid);
-        topic.toggleClass('unresolved', !data.isResolved);
+        topic.toggleClass('unresolve', !data.isResolved);
         topic.find('[component="topic/resolved"]').toggleClass('hide', !data.isResolved);
         ajaxify.refresh();
     }


### PR DESCRIPTION
Fixed #32. Resolves dropdown list not being able to show the field "Unresolve Topic" when trying to mark a post from 'resolved' to 'unresolved'. However, no action happens after clicking on the field, (the topic remains 'resolved). Further inspection is required on the `toggleResolve` function in `src/topics/tools.js`.

All related tests passed locally.

<img width="1440" alt="image" src="https://github.com/CMU-313/fall23-nodebb-tech-tartans/assets/107738264/913194e9-020d-4db7-a417-170df0492a90">