### PR TITLE
Implemented the backend logic of filtering unresolved topics.

### DIFF
--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -96,9 +96,9 @@ helpers.buildFilters = function (url, filter, query) {
         icon: 'fa-reply',
     }, {
         name: 'Unresolved Topics',
-        url: url + helpers.buildQueryString(query, 'filter', 'unreplied'),
-        selected: filter === 'unreplied',
-        filter: 'unreplied',
+        url: url + helpers.buildQueryString(query, 'filter', 'unresolved'),
+        selected: filter === 'unresolved',
+        filter: 'unresolved',
         icon: 'fa-question',
     }];
 };

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -20,6 +20,7 @@ require('./create')(Topics);
 require('./delete')(Topics);
 require('./sorted')(Topics);
 require('./unread')(Topics);
+require('./unresolved')(Topics);
 require('./recent')(Topics);
 require('./user')(Topics);
 require('./fork')(Topics);

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -84,8 +84,8 @@ module.exports = function (Topics) {
     };
 
     async function getTids(params) {
-        const counts = { '': 0, new: 0, watched: 0, unreplied: 0 , unresolved: 0 };
-        const tidsByFilter = { '': [], new: [], watched: [], unreplied: [] , unresolved: [] };
+        const counts = { '': 0, new: 0, watched: 0, unreplied: 0, unresolved: 0 };
+        const tidsByFilter = { '': [], new: [], watched: [], unreplied: [], unresolved: [] };
 
         if (params.uid <= 0) {
             return { counts: counts, tids: [], tidsByFilter: tidsByFilter };
@@ -110,7 +110,7 @@ module.exports = function (Topics) {
         const isUnresolved = {};
         tids_unresolved.forEach((t) => {
             isUnresolved[t.value] = true;
-        })
+        });
         const unreadFollowed = await db.isSortedSetMembers(
             `uid:${params.uid}:followed_tids`, tids_unread.map(t => t.value)
         );
@@ -399,6 +399,7 @@ module.exports = function (Topics) {
 
     Topics.filterUnresolvedTids = async function (tids) {
         const unresolvedTids = await db.getSortedSetRevRangeWithScores(`topics:unresolved`, 0, -1);
-        return unresolvedTids;
+        const unresolvedTidSet = new Set(unresolvedTids.map(item => item.member));
+        return tids.filter(tid => unresolvedTidSet.has(tid));
     };
 };

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -84,8 +84,8 @@ module.exports = function (Topics) {
     };
 
     async function getTids(params) {
-        const counts = { '': 0, new: 0, watched: 0, unreplied: 0 };
-        const tidsByFilter = { '': [], new: [], watched: [], unreplied: [] };
+        const counts = { '': 0, new: 0, watched: 0, unreplied: 0 , unresolved: 0 };
+        const tidsByFilter = { '': [], new: [], watched: [], unreplied: [] , unresolved: [] };
 
         if (params.uid <= 0) {
             return { counts: counts, tids: [], tidsByFilter: tidsByFilter };
@@ -136,7 +136,7 @@ module.exports = function (Topics) {
         });
 
         tids = await privileges.topics.filterTids('topics:read', tids, params.uid);
-        const topicData = (await Topics.getTopicsFields(tids, ['tid', 'cid', 'uid', 'postcount', 'deleted', 'scheduled']))
+        const topicData = (await Topics.getTopicsFields(tids, ['tid', 'cid', 'uid', 'postcount', 'deleted', 'scheduled', 'unresolved']))
             .filter(t => t.scheduled || !t.deleted);
         const topicCids = _.uniq(topicData.map(topic => topic.cid)).filter(Boolean);
 
@@ -163,6 +163,10 @@ module.exports = function (Topics) {
                 if (!userReadTimes[topic.tid]) {
                     tidsByFilter.new.push(topic.tid);
                 }
+
+                if (topic.unresolved) {
+                    tidsByFilter.unresolved.push(topic.tid);
+                }
             }
         });
 
@@ -170,6 +174,7 @@ module.exports = function (Topics) {
         counts.watched = tidsByFilter.watched.length;
         counts.unreplied = tidsByFilter.unreplied.length;
         counts.new = tidsByFilter.new.length;
+        counts.unresolved = tidsByFilter.unresolved.length;
 
         return {
             counts: counts,

--- a/src/topics/unresolved.js
+++ b/src/topics/unresolved.js
@@ -1,17 +1,230 @@
 
 'use strict';
 
+const async = require('async');
+const _ = require('lodash');
+
 const db = require('../database');
+const user = require('../user');
+const posts = require('../posts');
+const notifications = require('../notifications');
+const categories = require('../categories');
+const privileges = require('../privileges');
+const meta = require('../meta');
+const utils = require('../utils');
 const plugins = require('../plugins');
 
 module.exports = function (Topics) {
-    Topics.getUnresolvedTopics = async function (cid, uid, filter) {
-        return await Topics.getSortedTopics({
-            cids: cid,
-            uid: uid,
-            filter: filter,
-        });
+    Topics.getTotalUnresolved = async function (uid, filter) {
+        filter = filter || '';
+        const counts = await Topics.getUnresolvedTids({ cid: 0, uid: uid, count: true });
+        return counts && counts[filter];
     };
+
+    Topics.getUnresolvedTopics = async function (params) {
+        const unresolvedTopics = {
+            showSelect: true,
+            nextStart: 0,
+            topics: [],
+        };
+        let tids = await Topics.getUnresolvedTids(params);
+        unresolvedTopics.topicCount = tids.length;
+
+        if (!tids.length) {
+            return unresolvedTopics;
+        }
+
+        tids = tids.slice(params.start, params.stop !== -1 ? params.stop + 1 : undefined);
+
+        const topicData = await Topics.getTopicsByTids(tids, params.uid);
+        if (!topicData.length) {
+            return unresolvedTopics;
+        }
+        Topics.calculateTopicIndices(topicData, params.start);
+        unresolvedTopics.topics = topicData;
+        unresolvedTopics.nextStart = params.stop + 1;
+        return unresolvedTopics;
+    };
+
+    Topics.getUnresolvedTids = async function (params) {
+        const results = await Topics.getUnresolvedData(params);
+        return params.count ? results.counts : results.tids;
+    };
+
+    Topics.getUnresolvedData = async function (params) {
+        const uid = parseInt(params.uid, 10);
+
+        params.filter = params.filter || '';
+
+        if (params.cid && !Array.isArray(params.cid)) {
+            params.cid = [params.cid];
+        }
+
+        const data = await getTids(params);
+        if (uid <= 0 || !data.tids || !data.tids.length) {
+            return data;
+        }
+
+        const result = await plugins.hooks.fire('filter:topics.getUnresolvedTids', {
+            uid: uid,
+            tids: data.tids,
+            counts: data.counts,
+            tidsByFilter: data.tidsByFilter,
+            cid: params.cid,
+            filter: params.filter,
+            query: params.query || {},
+        });
+        return result;
+    };
+
+    async function getTids(params) {
+        const counts = { '': 0, new: 0, watched: 0, unreplied: 0 , unresolved: 0 };
+        const tidsByFilter = { '': [], new: [], watched: [], unreplied: [] , unresolved: [] };
+
+        if (params.uid <= 0) {
+            return { counts: counts, tids: [], tidsByFilter: tidsByFilter };
+        }
+
+        params.cutoff = await Topics.unreadCutoff(params.uid);
+
+        const [followedTids, ignoredTids, categoryTids, userScores, tids_unread, tids_unresolved] = await Promise.all([
+            getFollowedTids(params),
+            user.getIgnoredTids(params.uid, 0, -1),
+            getCategoryTids(params),
+            db.getSortedSetRevRangeByScoreWithScores(`uid:${params.uid}:tids_read`, 0, -1, '+inf', params.cutoff),
+            db.getSortedSetRevRangeWithScores(`uid:${params.uid}:tids_unread`, 0, -1),
+            db.getSortedSetRevRangeWithScores(`topics:unresolved`, 0, -1),
+        ]);
+
+        const userReadTimes = _.mapValues(_.keyBy(userScores, 'value'), 'score');
+        const isTopicsFollowed = {};
+        followedTids.forEach((t) => {
+            isTopicsFollowed[t.value] = true;
+        });
+        const unreadFollowed = await db.isSortedSetMembers(
+            `uid:${params.uid}:followed_tids`, tids_unread.map(t => t.value)
+        );
+
+        tids_unread.forEach((t, i) => {
+            isTopicsFollowed[t.value] = unreadFollowed[i];
+        });
+
+        if(!tids_unresolved.length) {
+            throw new Error('[[error:no-topic]]');
+        }
+
+        const unresolvedTopics = tids_unresolved
+            // .filter(t => tids_unresolved.includes(t.value))
+            .sort((a, b) => b.score - a.score);
+
+        if (!categoryTids.length) {
+            throw new Error('[[error:no-topic]]');
+        }
+
+        let tids = _.uniq(unresolvedTopics.map(topic => topic.value)).slice(0, 200);
+
+        if (!tids.length) {
+            return { counts: counts, tids: tids, tidsByFilter: tidsByFilter };
+        }
+        // throw new Error('[[error:no-topic]]');
+        const blockedUids = await user.blocks.list(params.uid);
+
+        tids = await filterTidsThatHaveBlockedPosts({
+            uid: params.uid,
+            tids: tids,
+            blockedUids: blockedUids,
+            recentTids: categoryTids,
+        });
+
+        tids = await privileges.topics.filterTids('topics:read', tids, params.uid);
+        const topicData = (await Topics.getTopicsFields(tids, ['tid', 'cid', 'uid', 'postcount', 'deleted', 'scheduled', 'unresolved']))
+            .filter(t => t.scheduled || !t.deleted);
+        const topicCids = _.uniq(topicData.map(topic => topic.cid)).filter(Boolean);
+
+        const categoryWatchState = await categories.getWatchState(topicCids, params.uid);
+        const userCidState = _.zipObject(topicCids, categoryWatchState);
+
+        const filterCids = params.cid && params.cid.map(cid => parseInt(cid, 10));
+
+        topicData.forEach((topic) => {
+            if (topic && topic.cid && (!filterCids || filterCids.includes(topic.cid)) &&
+                !blockedUids.includes(topic.uid)) {
+                if (isTopicsFollowed[topic.tid] || userCidState[topic.cid] === categories.watchStates.watching) {
+                    tidsByFilter[''].push(topic.tid);
+                }
+
+                if (isTopicsFollowed[topic.tid]) {
+                    tidsByFilter.watched.push(topic.tid);
+                }
+
+                if (topic.postcount <= 1) {
+                    tidsByFilter.unreplied.push(topic.tid);
+                }
+
+                if (!userReadTimes[topic.tid]) {
+                    tidsByFilter.new.push(topic.tid);
+                }
+
+                if (topic.unresolved) {
+                    tidsByFilter.unresolved.push(topic.tid);
+                }
+            }
+        });
+
+        counts[''] = tidsByFilter[''].length;
+        counts.watched = tidsByFilter.watched.length;
+        counts.unreplied = tidsByFilter.unreplied.length;
+        counts.new = tidsByFilter.new.length;
+        counts.unresolved = tidsByFilter.unresolved.length;
+
+        return {
+            counts: counts,
+            tids: tidsByFilter[params.filter],
+            tidsByFilter: tidsByFilter,
+        };
+    }
+
+    async function getCategoryTids(params) {
+        if (plugins.hooks.hasListeners('filter:topics.unresolved.getCategoryTids')) {
+            const result = await plugins.hooks.fire('filter:topics.unresolved.getCategoryTids', { params: params, tids: [] });
+            return result.tids;
+        }
+        if (params.filter === 'watched') {
+            return [];
+        }
+        const cids = params.cid || await user.getWatchedCategories(params.uid);
+        const keys = cids.map(cid => `cid:${cid}:tids:lastposttime`);
+        return await db.getSortedSetRevRangeByScoreWithScores(keys, 0, -1, '+inf', params.cutoff);
+    }
+
+    async function getFollowedTids(params) {
+        let tids = await db.getSortedSetMembers(`uid:${params.uid}:followed_tids`);
+        const filterCids = params.cid && params.cid.map(cid => parseInt(cid, 10));
+        if (filterCids) {
+            const topicData = await Topics.getTopicsFields(tids, ['tid', 'cid']);
+            tids = topicData.filter(t => filterCids.includes(t.cid)).map(t => t.tid);
+        }
+        const scores = await db.sortedSetScores('topics:recent', tids);
+        const data = tids.map((tid, index) => ({ value: String(tid), score: scores[index] }));
+        return data.filter(item => item.score > params.cutoff);
+    }
+
+    async function filterTidsThatHaveBlockedPosts(params) {
+        if (!params.blockedUids.length) {
+            return params.tids;
+        }
+        const topicScores = _.mapValues(_.keyBy(params.recentTids, 'value'), 'score');
+
+        const results = await db.sortedSetScores(`uid:${params.uid}:tids_read`, params.tids);
+
+        const userScores = _.zipObject(params.tids, results);
+
+        return await async.filter(params.tids, async tid => await doesTidHaveUnblockedUnreadPosts(tid, {
+            blockedUids: params.blockedUids,
+            topicTimestamp: topicScores[tid],
+            userLastReadTimestamp: userScores[tid],
+        }));
+    }
 
     Topics.markUnresolved = async function (tid) {
         let data = { tid: tid };

--- a/src/topics/unresolved.js
+++ b/src/topics/unresolved.js
@@ -193,7 +193,7 @@ module.exports = function (Topics) {
             return [];
         }
         const cids = params.cid || await user.getWatchedCategories(params.uid);
-        const keys = cids.map(cid => `cid:${cid}:tids:lastposttime`);
+        const keys = cids.map(cid => `cid:${cid}:tids`);
         return await db.getSortedSetRevRangeByScoreWithScores(keys, 0, -1, '+inf', params.cutoff);
     }
 

--- a/test/user.js
+++ b/test/user.js
@@ -1976,6 +1976,7 @@ describe('User', () => {
                     '': 4,
                     new: 4,
                     unreplied: 4,
+                    unresolved: 4,
                     watched: 0,
                 },
                 unreadNewTopicCount: 4,


### PR DESCRIPTION
Resolves #12. 

Implemented the backend logic of filtering unresolved topics from 'Unread' webpage.
<img width="1440" alt="image" src="https://github.com/CMU-313/fall23-nodebb-tech-tartans/assets/107738264/a42d8032-6e9f-4abd-a8f2-a9d2b18e79cd">
Implemented the backend logic of listing unresolved topics and showing relevant topics according to the filter used on the 'Unresolved' webpage.
<img width="1440" alt="image" src="https://github.com/CMU-313/fall23-nodebb-tech-tartans/assets/107738264/78b8de10-d196-4f22-8bc2-ca9d2d11ee8c">
<img width="1440" alt="image" src="https://github.com/CMU-313/fall23-nodebb-tech-tartans/assets/107738264/432fde66-3a89-4466-9e4b-8d278d973833">
<img width="1440" alt="image" src="https://github.com/CMU-313/fall23-nodebb-tech-tartans/assets/107738264/d05959a2-e56a-409b-9a9a-1e3d68de5e8a">
All local tests passed.

