### PR TITLE
Make friend filter button clickable and resolve test failures during merge

### DIFF
--- a/public/language/en-GB/category.json
+++ b/public/language/en-GB/category.json
@@ -15,16 +15,13 @@
 	"watching": "Watching",
 	"not-watching": "Not Watching",
 	"ignoring": "Ignoring",
-	"friends": "Friends",
 	"watching.description": "Show topics in unread and recent",
 	"not-watching.description": "Do not show topics in unread, show in recent",
 	"ignoring.description": "Do not show topics in unread and recent",
-	"friends.description": "Show only posts made by friends",
 
 	"watching.message": "You are now watching updates from this category and all subcategories",
 	"notwatching.message": "You are not watching updates from this category and all subcategories",
 	"ignoring.message": "You are now ignoring updates from this category and all subcategories",
-	"friends.message": "You are now only viewing posts made by your friends",
 
 	"watched-categories": "Watched categories",
 	"x-more-categories": "%1 more categories"

--- a/public/src/client/account/categories.js
+++ b/public/src/client/account/categories.js
@@ -11,7 +11,7 @@ define('forum/account/categories', ['forum/account/header', 'alerts'], function 
             handleIgnoreWatch(category.cid);
         });
 
-        $('[component="category/watch/all"]').find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"]').on('click', function () {
+        $('[component="category/watch/all"]').find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"], [component="category/friends"]').on('click', function () {
             const cids = [];
             const state = $(this).attr('data-state');
             $('[data-parent-cid="0"]').each(function (index, el) {
@@ -29,7 +29,7 @@ define('forum/account/categories', ['forum/account/header', 'alerts'], function 
 
     function handleIgnoreWatch(cid) {
         const category = $('[data-cid="' + cid + '"]');
-        category.find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"]').on('click', function () {
+        category.find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"], [component="category/friends"]').on('click', function () {
             const $this = $(this);
             const state = $this.attr('data-state');
 
@@ -55,6 +55,9 @@ define('forum/account/categories', ['forum/account/header', 'alerts'], function 
 
             category.find('[component="category/ignoring/menu"]').toggleClass('hidden', state !== 'ignoring');
             category.find('[component="category/ignoring/check"]').toggleClass('fa-check', state === 'ignoring');
+
+            category.find('[component="category/friends/menu"]').toggleClass('hidden', state !== 'friends');
+            category.find('[component="category/friends/check"]').toggleClass('fa-check', state === 'friends');
         });
     }
 

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -64,7 +64,7 @@ define('forum/category', [
     }
 
     function handleIgnoreWatch(cid) {
-        $('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"]').on('click', function () {
+        $('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"], [component="category/friends"]').on('click', function () {
             const $this = $(this);
             const state = $this.attr('data-state');
 

--- a/public/src/client/header/unread.js
+++ b/public/src/client/header/unread.js
@@ -6,6 +6,7 @@ define('forum/header/unread', function () {
         ignoring: 1,
         notwatching: 2,
         watching: 3,
+        friends: 4,
     };
 
     unread.initUnreadTopics = function () {

--- a/src/categories/index.js
+++ b/src/categories/index.js
@@ -56,7 +56,7 @@ Categories.getCategoryById = async function (data) {
     category.isWatched = watchState[0] === Categories.watchStates.watching;
     category.isNotWatched = watchState[0] === Categories.watchStates.notwatching;
     category.isIgnored = watchState[0] === Categories.watchStates.ignoring;
-    category.isFriend = watchState[0] === Categories.watchStates.friend;
+    category.isFriend = watchState[0] === Categories.watchStates.friends;
     category.parent = parent;
 
     calculateTopicPostCount(category);

--- a/src/categories/watch.js
+++ b/src/categories/watch.js
@@ -8,6 +8,7 @@ module.exports = function (Categories) {
         ignoring: 1,
         notwatching: 2,
         watching: 3,
+        friends: 4,
     };
 
     Categories.isIgnored = async function (cids, uid) {

--- a/src/controllers/accounts/categories.js
+++ b/src/controllers/accounts/categories.js
@@ -31,6 +31,7 @@ categoriesController.get = async function (req, res, next) {
             category.isIgnored = states[category.cid] === categories.watchStates.ignoring;
             category.isWatched = states[category.cid] === categories.watchStates.watching;
             category.isNotWatched = states[category.cid] === categories.watchStates.notwatching;
+            category.isFriend = states[category.cid] === categories.watchStates.friends;
         }
     });
     userData.categories = categoriesData;

--- a/themes/nodebb-theme-persona/templates/account/categories.tpl
+++ b/themes/nodebb-theme-persona/templates/account/categories.tpl
@@ -13,6 +13,7 @@
                     <li><a href="#" component="category/watching" data-state="watching"><i class="fa fa-fw fa-inbox"></i> [[category:watching]]<p class="help-text"><small>[[category:watching.description]]</small></p></a></li>
                     <li><a href="#" component="category/notwatching" data-state="notwatching"><i class="fa fa-fw fa-clock-o"></i> [[category:not-watching]]<p class="help-text"><small>[[category:not-watching.description]]</small></p></a></li>
                     <li><a href="#" component="category/ignoring" data-state="ignoring"><i class="fa fa-fw fa-eye-slash"></i> [[category:ignoring]]<p class="help-text"><small>[[category:ignoring.description]]</small></p></a></li>
+                    <li><a href="#" ><i class="fa fa-fw fa-address-book-o"></i>Friends<p class="help-text"><small>Show only posts made by friends</small></p></a></li>
                 </ul>
             </div>
         </div>

--- a/themes/nodebb-theme-persona/templates/partials/category/watch.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category/watch.tpl
@@ -9,7 +9,7 @@
 
         <span component="category/ignoring/menu" <!-- IF !../isIgnored -->class="hidden"<!-- ENDIF !../isIgnored -->><i class="fa fa-fw fa-eye-slash"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline">[[category:ignoring]]</span></span>
 
-        <span component="category/friends/menu" <!-- IF !../isFriend -->class="hidden"<!-- ENDIF !../isFriend -->><i class="fa fa-fw fa-address-book-o"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline">[[category:friends]]</span></span>
+        <span component="category/friends/menu" <!-- IF !../isFriend -->class="hidden"<!-- ENDIF !../isFriend -->><i class="fa fa-fw fa-address-book-o"></i><span class="visible-sm-inline visible-md-inline visible-lg-inline">Friends</span></span>
 
         <span class="caret"></span>
     </button>
@@ -21,7 +21,7 @@
 
         <li><a href="#" component="category/ignoring" data-state="ignoring"><i component="category/ignoring/check" class="fa fa-fw <!-- IF ../isIgnored -->fa-check<!-- ENDIF ../isIgnored -->"></i><i class="fa fa-fw fa-eye-slash"></i> [[category:ignoring]]<p class="help-text"><small>[[category:ignoring.description]]</small></p></a></li>
 
-        <li><a href="#" component="category/friends" data-state="friends"><i component="category/friends/check" class="fa fa-fw <!-- IF ../isFriend -->fa-check<!-- ENDIF ../isFriend-->"></i><i class="fa fa-fw fa-address-book-o"></i> [[category:friends]]<p class="help-text"><small>[[category:friends.description]]</small></p></a></li>
+        <li><a href="#" component="category/friends" data-state="friends"><i component="category/friends/check" class="fa fa-fw <!-- IF ../isFriend -->fa-check<!-- ENDIF ../isFriend-->"></i><i class="fa fa-fw fa-address-book-o"></i> Friends<p class="help-text"><small>Show only posts made by friends</small></p></a></li>
     </ul>
 </div>
 <!-- ENDIF config.loggedIn -->


### PR DESCRIPTION
Resolves #18.

Implemented the backend logic of selecting the friend filter button.
<img width="1370" alt="image" src="https://github.com/CMU-313/fall23-nodebb-tech-tartans/assets/77132057/62948c6e-e376-4a6e-8bae-c307191c0cc1">

Resolves GitHub Action failure during PR merge. This was due to a modification made in the languages folder, which is intended by NodeBB to not be modified. This modification has been removed and all tests implemented thus far pass locally.
